### PR TITLE
[OS X Compilation Fix] Resolve ambiguous call with as_buffer

### DIFF
--- a/src/bits/buffers.h
+++ b/src/bits/buffers.h
@@ -60,6 +60,11 @@ inline std::vector<uint8_t> as_buffer(const std::string& r)
 {
     return std::vector<uint8_t>(r.begin(), r.end());
 }
+inline std::vector<uint8_t> as_buffer(unsigned long r)
+{
+    return std::vector<uint8_t>((uint8_t *)&r, (uint8_t *)(&r + 1));
+}
+    
 
 inline void pack_value(char r, std::vector<uint8_t>& buf)
 {


### PR DESCRIPTION
Simple fix to resolve compilation failure on OS X with Clang. OS X defines type_t as unsigned long instead of uint32_t or uint64_t.
