### PR TITLE
Fix pythonBindings.cpp source path in setup.py & ignore CMake/Linux artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
+## CMake
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+## GNU Linux/Make
+Makefile
+*.a
+*.so
+## Local IDE
+.idea/
+## Misc artifacts
 build/
 *.pyc

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ $ cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
 $ sudo cp libbamboo.so /lib
 ```
 
+- Install the `PyBindGen` pip module to the python environment of your choice. (required to run setup.py)
 - Build the Bamboo python module using the `setup.py` script in the `bindings/python` directory.
 ```bash
 $ cd bindings/python
+$ python2 -m pip install pybindgen
 $ python2 setup.py build
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Bamboo
+A library and tools for object-oriented network protocols. [Work in progress]
+
+----------------
+
+## Build Instructions for GNU Linux/Make (Python bindings)
+
+- Compile the Bamboo C++ source and build the Bamboo shared library using CMake.
+```bash
+$ cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
+```
+
+- A `libbamboo.so` shared object file should have been generated in the current directory.
+- Copy the shared object file to your `/lib` directory. The next step requires this library to be installed.
+```bash
+$ sudo cp libbamboo.so /lib
+```
+
+- Build the Bamboo python module using the `setup.py` script in the `bindings/python` directory.
+```bash
+$ cd bindings/python
+$ python2 setup.py build
+```
+
+- Setup and install the bamboo module in your Python environment.
+- **NOTE:** If you're using a virtual environment, replace 'python2' with the path to your venv python binary.
+```bash
+$ python2 setup.py install
+```

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A library and tools for object-oriented network protocols. [Work in progress]
 
 ## Build Instructions for GNU Linux/Make (Python bindings)
 
-- Compile the Bamboo C++ source and build the Bamboo shared library using CMake.
+- Compile the Bamboo C++ source and tell CMake to build the Bamboo shared library.
 ```bash
-$ cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
+$ cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 && make
 ```
 
 - A `libbamboo.so` shared object file should have been generated in the current directory.

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -9,7 +9,7 @@ libraryDirs = [buildDir]
 
 module = Extension('bamboo',
     include_dirs = includeDirs,
-    sources = ['pythonBindings.cpp'],
+    sources = ['prebuilt/pythonBindings.cpp'],
     libraries = ['bamboo'],
     library_dirs = libraryDirs)
 module.extra_compile_args = ['--std=c++11']


### PR DESCRIPTION
The `setup.py` in `bindings/python` didn't have the correct path to the `pythonBindings.cpp` file if ran in the `bindings/python` directory; Fixed this small issue. Added CMake/Make build artifacts to the .gitignore file for those compiling Bamboo on Unix-like systems. Also added a README.md to the project that has build instructions on how to build the bamboo shared library, how to build the bamboo python module, and installing the bamboo python module.